### PR TITLE
fix(react): use react in peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tari-extension",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Tari VS Code extension",
   "type": "module",
   "keywords": [],

--- a/packages/tari-extension-common/package.json
+++ b/packages/tari-extension-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tari-project/tari-extension-common",
   "private": false,
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Tari VS Code extension common code",
   "scripts": {
     "build:cjs": "tsc -p tsconfig.json",

--- a/packages/tari-extension-query-builder-webview/package.json
+++ b/packages/tari-extension-query-builder-webview/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tari-extension-query-builder-webview",
   "private": true,
-  "version": "0.0.6",
+  "version": "0.0.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/tari-extension-query-builder/package.json
+++ b/packages/tari-extension-query-builder/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tari-project/tari-extension-query-builder",
   "private": false,
-  "version": "0.0.6",
+  "version": "0.0.7",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -30,6 +30,10 @@
   "sideEffects": [
     "./dist/tari-extension-query-builder.css"
   ],
+  "peerDependencies": {
+    "react": ">=17.0.0",
+    "react-dom": ">=17.0.0"
+  },
   "dependencies": {
     "@ladle/react": "^5.0.1",
     "@radix-ui/react-alert-dialog": "^1.1.6",
@@ -51,8 +55,6 @@
     "lucide-react": "^0.479.0",
     "next-themes": "^0.4.6",
     "postcss": "^8.5.3",
-    "react": "catalog:",
-    "react-dom": "catalog:",
     "sonner": "^2.0.3",
     "tailwind-merge": "^3.0.2",
     "tailwindcss": "^4.0.12",
@@ -75,6 +77,8 @@
     "eslint-plugin-react-refresh": "catalog:",
     "globals": "catalog:",
     "prettier": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
     "typescript": "catalog:",
     "typescript-eslint": "catalog:",
     "vite": "catalog:",

--- a/packages/tari-extension-webview/package.json
+++ b/packages/tari-extension-webview/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tari-extension-webview",
   "private": true,
-  "version": "0.0.6",
+  "version": "0.0.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/tari-extension/package.json
+++ b/packages/tari-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tari-extension",
-  "publisher": "tari-labs",
-  "version": "0.0.6",
+  "publisher": "TariLabsLLC",
+  "version": "0.0.7",
   "displayName": "Tari Ootle",
   "description": "Improves the Tari experience",
   "keywords": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -210,12 +210,6 @@ importers:
       postcss:
         specifier: ^8.5.3
         version: 8.5.3
-      react:
-        specifier: 'catalog:'
-        version: 19.0.0
-      react-dom:
-        specifier: 'catalog:'
-        version: 19.0.0(react@19.0.0)
       sonner:
         specifier: ^2.0.3
         version: 2.0.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -274,6 +268,12 @@ importers:
       prettier:
         specifier: 'catalog:'
         version: 3.5.2
+      react:
+        specifier: 'catalog:'
+        version: 19.0.0
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.0.0(react@19.0.0)
       typescript:
         specifier: 'catalog:'
         version: 5.7.3


### PR DESCRIPTION
Description
---

Register `react` and `react-dom` dependencies in `peerDependencies` instead of `dependencies`.

Motivation and Context
---

The `@tari-project/tari-extension-query-builder` is supposed to be used in external applications as well.
And they might use different `react` version from one used in this project.
If `react` versions differ, react loads two different instances of react runtime and this `QueryBuilder` component fails to load.


<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
