### PR TITLE
fix(query-builder): restore browser default css

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tari-extension",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Tari VS Code extension",
   "type": "module",
   "keywords": [],

--- a/packages/tari-extension-common/package.json
+++ b/packages/tari-extension-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tari-project/tari-extension-common",
   "private": false,
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Tari VS Code extension common code",
   "scripts": {
     "build:cjs": "tsc -p tsconfig.json",

--- a/packages/tari-extension-query-builder-webview/package.json
+++ b/packages/tari-extension-query-builder-webview/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tari-extension-query-builder-webview",
   "private": true,
-  "version": "0.0.10",
+  "version": "0.0.11",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/tari-extension-query-builder/package.json
+++ b/packages/tari-extension-query-builder/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tari-project/tari-extension-query-builder",
   "private": false,
-  "version": "0.0.10",
+  "version": "0.0.11",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/tari-extension-query-builder/src/browser-defaults.css
+++ b/packages/tari-extension-query-builder/src/browser-defaults.css
@@ -62,7 +62,8 @@ p {
 }
 
 /* Lists */
-ul, ol {
+ul,
+ol {
   list-style-type: initial; /* Restore bullet/number styles */
   margin-block-start: 1em;
   margin-block-end: 1em;
@@ -91,7 +92,9 @@ pre {
 }
 
 /* Code */
-code, kbd, samp {
+code,
+kbd,
+samp {
   font-family: monospace, monospace;
   font-size: 1em; /* Restore browser default size */
 }
@@ -101,7 +104,8 @@ a {
   text-decoration: underline; /* Default underline */
 }
 
-a:active, a:hover {
+a:active,
+a:hover {
   outline-width: 0;
 }
 
@@ -189,11 +193,13 @@ small {
   font-size: 0.83em; /* Approximate default for <small> */
 }
 
-strong, b {
+strong,
+b {
   font-weight: bolder; /* Make sure they are bolder than parent, not just bold */
 }
 
-em, i {
+em,
+i {
   font-style: italic;
 }
 
@@ -218,7 +224,8 @@ progress {
 }
 
 /* Sub/Sup */
-sub, sup {
+sub,
+sup {
   font-size: 75%;
   line-height: 0;
   position: relative;

--- a/packages/tari-extension-query-builder/src/browser-defaults.css
+++ b/packages/tari-extension-query-builder/src/browser-defaults.css
@@ -1,0 +1,250 @@
+/*
+ * Custom CSS to revert common HTML elements to approximate browser default styles.
+ *
+ * This should be loaded AFTER Tailwind CSS's base styles to override Preflight.
+ */
+
+/* Box sizing for all elements - keep standard browser behavior (content-box for most) */
+*,
+::before,
+::after {
+  box-sizing: border-box; /* Or content-box if you want true legacy browser box model */
+}
+
+/* Headings */
+h1 {
+  font-size: 2em; /* ~32px */
+  margin-block-start: 0.67em;
+  margin-block-end: 0.67em;
+  font-weight: bold;
+}
+
+h2 {
+  font-size: 1.5em; /* ~24px */
+  margin-block-start: 0.83em;
+  margin-block-end: 0.83em;
+  font-weight: bold;
+}
+
+h3 {
+  font-size: 1.17em; /* ~18.72px */
+  margin-block-start: 1em;
+  margin-block-end: 1em;
+  font-weight: bold;
+}
+
+h4 {
+  font-size: 1em; /* ~16px */
+  margin-block-start: 1.33em;
+  margin-block-end: 1.33em;
+  font-weight: bold;
+}
+
+h5 {
+  font-size: 0.83em; /* ~13.28px */
+  margin-block-start: 1.67em;
+  margin-block-end: 1.67em;
+  font-weight: bold;
+}
+
+h6 {
+  font-size: 0.67em; /* ~10.72px */
+  margin-block-start: 2.33em;
+  margin-block-end: 2.33em;
+  font-weight: bold;
+}
+
+/* Paragraphs */
+p {
+  margin-block-start: 1em;
+  margin-block-end: 1em;
+  line-height: normal; /* Restore typical browser line-height for paragraphs */
+}
+
+/* Lists */
+ul, ol {
+  list-style-type: initial; /* Restore bullet/number styles */
+  margin-block-start: 1em;
+  margin-block-end: 1em;
+  padding-inline-start: 40px; /* Default indentation */
+}
+
+li {
+  display: list-item; /* Ensure list items behave as such */
+}
+
+/* Blockquote */
+blockquote {
+  margin-block-start: 1em;
+  margin-block-end: 1em;
+  margin-inline-start: 40px;
+  margin-inline-end: 40px;
+}
+
+/* Preformatted text */
+pre {
+  font-family: monospace, monospace;
+  font-size: 1em;
+  margin-block-start: 1em;
+  margin-block-end: 1em;
+  white-space: pre; /* Ensure proper whitespace handling */
+}
+
+/* Code */
+code, kbd, samp {
+  font-family: monospace, monospace;
+  font-size: 1em; /* Restore browser default size */
+}
+
+/* Links */
+a {
+  text-decoration: underline; /* Default underline */
+}
+
+a:active, a:hover {
+  outline-width: 0;
+}
+
+/* Images */
+img {
+  display: inline-block; /* Or block if that's more suitable for your layout */
+  vertical-align: middle; /* Common default */
+  max-width: 100%; /* Important for responsive images */
+  height: auto; /* Maintain aspect ratio */
+}
+
+/* Figures */
+figure {
+  margin-block-start: 1em;
+  margin-block-end: 1em;
+  margin-inline-start: 40px;
+  margin-inline-end: 40px;
+}
+
+/* Form elements */
+button,
+input,
+optgroup,
+select,
+textarea {
+  font-family: inherit; /* Inherit font from parent */
+  font-size: 100%; /* Default font size */
+  line-height: 1.15; /* Maintain consistent line-height */
+  margin: 0; /* Remove potential margin from preflight */
+  padding: initial; /* Remove padding, let browser defaults or specific styles apply */
+  border: initial; /* Restore default borders */
+  border-radius: initial; /* Restore default border-radius */
+  appearance: auto; /* Restore browser-specific styling for form elements */
+}
+
+button,
+[type="button"],
+[type="reset"],
+[type="submit"] {
+  -webkit-appearance: button; /* Restore default button appearance for webkit */
+}
+
+button::-moz-focus-inner,
+[type="button"]::-moz-focus-inner,
+[type="reset"]::-moz-focus-inner,
+[type="submit"]::-moz-focus-inner {
+  border-style: none; /* Remove focus inner border for Firefox */
+  padding: 0;
+}
+
+button:-moz-focusring,
+[type="button"]:-moz-focusring,
+[type="reset"]:-moz-focusring,
+[type="submit"]:-moz-focusring {
+  outline: 1px dotted ButtonText; /* Restore Firefox focus ring */
+}
+
+textarea {
+  overflow: auto; /* Scrollbars when content overflows */
+  resize: vertical; /* Allow vertical resizing by default */
+  vertical-align: top; /* Align with top for multi-line input */
+}
+
+[type="search"] {
+  -webkit-appearance: textfield; /* Restore textfield appearance for search inputs */
+  outline-offset: -2px; /* Restore outline offset */
+}
+
+[type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+/* Details and Summary */
+details {
+  display: block;
+}
+
+summary {
+  display: list-item; /* Allow browser default disclosure triangle */
+  cursor: pointer; /* Indicate interactivity */
+}
+
+/* Small, Strong, Em, etc. */
+small {
+  font-size: 0.83em; /* Approximate default for <small> */
+}
+
+strong, b {
+  font-weight: bolder; /* Make sure they are bolder than parent, not just bold */
+}
+
+em, i {
+  font-style: italic;
+}
+
+/* hr */
+hr {
+  box-sizing: content-box; /* Or border-box depending on your preference */
+  height: 0; /* No height by default */
+  overflow: visible; /* Ensure borders are visible */
+  border-top: 1px solid #e5e7eb; /* Tailwind's default border-color-200 */
+  margin: 1em 0; /* Add vertical margin */
+}
+
+/* Audio/Video */
+audio,
+video {
+  display: inline-block; /* Or block depending on typical usage */
+}
+
+/* Progress */
+progress {
+  vertical-align: baseline;
+}
+
+/* Sub/Sup */
+sub, sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+
+sub {
+  bottom: -0.25em;
+}
+
+sup {
+  top: -0.5em;
+}
+
+/* Tables */
+table {
+  border-collapse: collapse; /* Ensure standard table rendering */
+  border-spacing: 2px;
+  text-indent: 0;
+}
+
+caption {
+  text-align: center;
+}
+
+th {
+  text-align: -webkit-match-parent; /* Default align for table headers */
+  font-weight: bold;
+}

--- a/packages/tari-extension-query-builder/src/index.css
+++ b/packages/tari-extension-query-builder/src/index.css
@@ -1,5 +1,5 @@
 @import "tailwindcss";
-@import "./browser-defaults.css"
+@import "./browser-defaults.css";
 
 @plugin "tailwindcss-animate";
 

--- a/packages/tari-extension-query-builder/src/index.css
+++ b/packages/tari-extension-query-builder/src/index.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@import "./browser-defaults.css"
 
 @plugin "tailwindcss-animate";
 

--- a/packages/tari-extension-webview/package.json
+++ b/packages/tari-extension-webview/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tari-extension-webview",
   "private": true,
-  "version": "0.0.10",
+  "version": "0.0.11",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/tari-extension/package.json
+++ b/packages/tari-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tari-extension",
   "publisher": "TariLabsLLC",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "displayName": "Tari Ootle",
   "description": "Improves the Tari experience",
   "keywords": [


### PR DESCRIPTION
Description
---

We publish query builder react component. It uses shadcn/ui, which requires tailwind preflight css.
But some apps, which include this react component, rely on default browser styles.
This change restores basic styles to their default values.


How Has This Been Tested?
---

By running the component locally.

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
