### PR TITLE
fix(ci): fix publish to gh-pages

### DIFF
--- a/.github/workflows/publish_schemas.yml
+++ b/.github/workflows/publish_schemas.yml
@@ -34,6 +34,7 @@ jobs:
     permissions:
       pages: write
       id-token: write
+      contents: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
Description
---

```
Run cd gh-pages
  cd gh-pages
  git config user.name "github-actions[bot]"
  git config user.email "github-actions[bot]@users.noreply.github.com"
  git add schemas/*.json
  git commit -m "Update latest JSON schema" || echo "No changes to commit"
  git push origin gh-pages
  shell: /usr/bin/bash -e {0}
[gh-pages 69dc653] Update latest JSON schema
 1 file changed, 18297 insertions(+)
 create mode 100644 schemas/tari-schema-v1.0.json
remote: Permission to tari-project/tari-vscode-nocode-extension.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/tari-project/tari-vscode-nocode-extension/': The requested URL returned error: 403
Error: Process completed with exit code 128.
```

Motivation and Context
---

How Has This Been Tested?
---

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
