### PR TITLE
fix: add change callback props

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tari-extension",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "Tari VS Code extension",
   "type": "module",
   "keywords": [],

--- a/packages/tari-extension-common/package.json
+++ b/packages/tari-extension-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tari-project/tari-extension-common",
   "private": false,
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "Tari VS Code extension common code",
   "scripts": {
     "build:cjs": "tsc -p tsconfig.json",

--- a/packages/tari-extension-query-builder-webview/package.json
+++ b/packages/tari-extension-query-builder-webview/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tari-extension-query-builder-webview",
   "private": true,
-  "version": "0.0.14",
+  "version": "0.0.15",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/tari-extension-query-builder/package.json
+++ b/packages/tari-extension-query-builder/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tari-project/tari-extension-query-builder",
   "private": false,
-  "version": "0.0.14",
+  "version": "0.0.15",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/tari-extension-query-builder/src/components/query-builder/query-builder.tsx
+++ b/packages/tari-extension-query-builder/src/components/query-builder/query-builder.tsx
@@ -7,6 +7,9 @@ import {
   Viewport,
   Panel,
   MiniMap,
+  OnEdgesChange,
+  OnNodesChange,
+  OnConnect,
 } from "@xyflow/react";
 import {
   CALL_NODE_DRAG_DROP_TYPE,
@@ -94,6 +97,9 @@ export interface QueryBuilderProps {
   getTransactionProps?: () => Promise<TransactionProps>;
   executeTransaction?: (transaction: UnsignedTransactionV1) => Promise<void>;
   showGeneratedCode?: (code: string, type: GeneratedCodeType) => Promise<void>;
+  onEdgesChange?: OnEdgesChange;
+  onNodesChange?: OnNodesChange;
+  onConnect?: OnConnect;
 }
 
 const nodeTypes = {
@@ -111,6 +117,9 @@ function Flow({
   getTransactionProps,
   executeTransaction,
   showGeneratedCode,
+  onEdgesChange: onEdgesChangeCallback,
+  onNodesChange: onNodesChangeCallback,
+  onConnect: onConnectCallback,
 }: QueryBuilderProps) {
   const {
     nodes,
@@ -465,9 +474,18 @@ function Flow({
           edgeTypes={edgeTypes}
           nodes={nodes}
           edges={edges}
-          onNodesChange={onNodesChange}
-          onEdgesChange={onEdgesChange}
-          onConnect={onConnect}
+          onNodesChange={(change) => {
+            onNodesChange(change);
+            onNodesChangeCallback?.(change);
+          }}
+          onEdgesChange={(change) => {
+            onEdgesChange(change);
+            onEdgesChangeCallback?.(change);
+          }}
+          onConnect={(connection) => {
+            onConnect(connection);
+            onConnectCallback?.(connection);
+          }}
           onMove={onMove}
           onDragOver={onDragOver}
           onDrop={onDrop}

--- a/packages/tari-extension-query-builder/src/store/store.ts
+++ b/packages/tari-extension-query-builder/src/store/store.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 import { addEdge, applyNodeChanges, applyEdgeChanges } from "@xyflow/react";
 import { v4 as uuidv4 } from "uuid";
-import { CustomNode, InputConnectionType, NodeType, type QueryBuilderState } from "./types";
+import { CustomNode, InputConnectionType, NodeType, type QueryBuilderState, SchemaAndVersion } from "./types";
 import { NODE_ENTRY, NODE_EXIT } from "@/components/query-builder/nodes/generic-node.types";
 import { getSchemaFullPath, latestVersionHandler, versionHandlers } from "./persistence/handlers";
 import { NEW_INPUT_PARAM } from "@/components/query-builder/nodes/input/constants";
@@ -12,6 +12,7 @@ import {
   CALL_NODE_RETURN_TUPLE_2,
 } from "@/components/query-builder/nodes/call-node.types";
 import { TariType } from "@/query-builder/tari-type";
+import { LatestPersistedState } from "@/store/persistence/types.ts";
 
 const DROP_NODE_OFFSET_X = 200;
 const DROP_NODE_OFFSET_Y = 50;
@@ -242,43 +243,30 @@ const useStore = create<QueryBuilderState>((set, get) => ({
     }
   },
   saveStateToString: () => {
+    const { getState } = get();
+    const state = getState();
+    return JSON.stringify(state, undefined, 2);
+  },
+  loadStateFromString: (state) => {
+    let parsedState: SchemaAndVersion & LatestPersistedState;
+    try {
+      parsedState = JSON.parse(state) as SchemaAndVersion & LatestPersistedState;
+    } catch (error) {
+      throw new Error(`Failed to parse state: ${String(error)}`);
+    }
+
+    set(validateState(parsedState));
+  },
+  getState: () => {
     const state = get();
     const persistedState = latestVersionHandler.save(state);
-    const withSchema = {
+    return {
       $schema: getSchemaFullPath(persistedState.version),
       ...persistedState,
     };
-    return JSON.stringify(withSchema, undefined, 2);
   },
-  loadStateFromString: (state) => {
-    try {
-      const parsedState = JSON.parse(state) as { version?: string } | undefined;
-      if (typeof parsedState?.version !== "string") {
-        throw new Error("Invalid persisted state: Missing or invalid version.");
-      }
-
-      const version = parsedState.version;
-      const handler = versionHandlers[version];
-
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-      if (!handler) {
-        throw new Error(`No handler found for version: ${version}`);
-      }
-
-      const validationResult = handler.load(parsedState);
-
-      if (validationResult.success) {
-        if (version === "1.0") {
-          set({ nodes: validationResult.data.nodes, edges: validationResult.data.edges });
-        } else {
-          throw new Error(`Unsupported version: ${version}`);
-        }
-      } else {
-        throw new Error(`Validation failed: ${validationResult.error.toString()}`);
-      }
-    } catch (error) {
-      throw new Error(`Failed to load state: ${String(error)}`);
-    }
+  setState: (state) => {
+    set(validateState(state));
   },
   isValidInputParamsTitle: (nodeId, title) => {
     if (!title.length || /\s/g.test(title) || !/^[a-zA-Z]/.test(title)) {
@@ -357,7 +345,7 @@ const useStore = create<QueryBuilderState>((set, get) => ({
     }
   },
   isValidInputParamsName: (nodeId, paramId, name) => {
-    if (!name.length || /\s/g.test(name) || !!/^[a-zA-Z]/.test(name)) {
+    if (!name.length || /\s/g.test(name) || /^[a-zA-Z]/.test(name)) {
       return false;
     }
     const node = get().getNodeById(nodeId);
@@ -396,5 +384,36 @@ const useStore = create<QueryBuilderState>((set, get) => ({
     }
   },
 }));
+
+function validateState(state: (SchemaAndVersion & LatestPersistedState) | undefined) {
+  if (typeof state?.version !== "string") {
+    throw new Error("Invalid persisted state: Missing or invalid version.");
+  }
+
+  try {
+    const version = state.version;
+    const handler = versionHandlers[version];
+
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (!handler) {
+      throw new Error(`No handler found for version: ${version}`);
+    }
+
+    const validationResult = handler.load(state);
+
+    if (validationResult.success) {
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      if (version === "1.0") {
+        return { nodes: validationResult.data.nodes, edges: validationResult.data.edges };
+      } else {
+        throw new Error(`Unsupported version: ${String(version)}`);
+      }
+    } else {
+      throw new Error(`Validation failed: ${validationResult.error.toString()}`);
+    }
+  } catch (error) {
+    throw new Error(`Failed to load state: ${String(error)}`);
+  }
+}
 
 export default useStore;

--- a/packages/tari-extension-query-builder/src/store/types.ts
+++ b/packages/tari-extension-query-builder/src/store/types.ts
@@ -9,6 +9,7 @@ import {
   XYPosition,
 } from "@xyflow/react";
 import { SafeParseReturnType } from "zod";
+import { LatestPersistedState } from "@/store/persistence/types.ts";
 
 export enum NodeType {
   GenericNode = "genericNode",
@@ -34,11 +35,13 @@ export interface CallNodeMetadata {
 
 export type GenericNodeMetadata = CallNodeMetadata;
 export type GenericNodeIcon = "enter" | "rocket" | "home" | "cube" | "check-circled" | "archive" | "component";
+
 export enum InputConnectionType {
   None = 0,
   Parameter,
   ComponentAddress,
 }
+
 export interface GenericNodeInputType {
   inputConnectionType: InputConnectionType;
   type: Type;
@@ -46,11 +49,13 @@ export interface GenericNodeInputType {
   label?: string;
   validValues?: string[];
 }
+
 export interface GenericNodeOutputType {
   type: Type;
   name: string;
   label?: string;
 }
+
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type GenericNodeData = {
   type: GenericNodeType;
@@ -84,6 +89,11 @@ export type InputParamsNode = Node<InputParamsNodeData, NodeType.InputParamsNode
 
 export type CustomNode = GenericNode | InputParamsNode;
 
+export interface SchemaAndVersion {
+  $schema: string;
+  version: string;
+}
+
 export interface QueryBuilderState {
   readOnly: boolean;
   nodes: CustomNode[];
@@ -106,6 +116,8 @@ export interface QueryBuilderState {
   removeNode: (nodeId: string) => void;
   saveStateToString: () => string;
   loadStateFromString: (state: string) => void;
+  setState: (state: SchemaAndVersion & LatestPersistedState) => void;
+  getState: () => SchemaAndVersion & LatestPersistedState;
   isValidInputParamsTitle: (nodeId: string, title: string) => boolean;
   updateInputParamsTitle: (nodeId: string, title: string) => void;
   updateInputParamsNode: (nodeId: string, paramId: string, value: SafeParseReturnType<unknown, unknown>) => void;

--- a/packages/tari-extension-query-builder/src/types.ts
+++ b/packages/tari-extension-query-builder/src/types.ts
@@ -5,3 +5,20 @@ export interface TariFlowNodeDetails {
   templateAddress: string;
   functionName: string;
 }
+
+// Extend BigInt to support JSON serialization
+declare global {
+  interface BigInt {
+    toJSON(): string | number;
+  }
+}
+
+BigInt.prototype.toJSON = function () {
+  // if the number is too large, return it as a string
+  // otherwise return it as a number
+  const int = this.valueOf();
+  if (int > BigInt(Number.MAX_SAFE_INTEGER) || int < BigInt(Number.MIN_SAFE_INTEGER)) {
+    return this.toString();
+  }
+  return Number(this);
+};

--- a/packages/tari-extension-webview/package.json
+++ b/packages/tari-extension-webview/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tari-extension-webview",
   "private": true,
-  "version": "0.0.14",
+  "version": "0.0.15",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/tari-extension/package.json
+++ b/packages/tari-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tari-extension",
   "publisher": "TariLabsLLC",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "displayName": "Tari Ootle",
   "description": "Improves the Tari experience",
   "keywords": [


### PR DESCRIPTION
Description
---
fix: add change callback props
bump version 0.0.15

Motivation and Context
---
Callbacks that allow client apps to act on changes.

Also added get state and set state which are similar to saveStateToString and loadStateFromString but without JSON stringify and parse. 

Together these can be used to (for example) persist the flow state in localStorage as soon as something changes 

How Has This Been Tested?
---

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
