### PR TITLE
fix: serialize bigint

### DIFF
--- a/packages/tari-extension-query-builder/src/query-builder/tari-type.ts
+++ b/packages/tari-extension-query-builder/src/query-builder/tari-type.ts
@@ -1,6 +1,7 @@
 import { Type } from "@tari-project/typescript-bindings";
 import { HTMLInputTypeAttribute } from "react";
 import { SafeParseReturnType, z, ZodFirstPartySchemaTypes } from "zod";
+import { WrappedBigInt } from "./wrapped-bigint";
 
 export enum InputControlType {
   TextBoxInput = "TextBoxInput",
@@ -178,7 +179,8 @@ function getTypeProps(type: Type): TypeProps {
       })
       .refine((val) => BigInt(val) <= maxValue, {
         message: `Value must be less than or equal to ${maxValue.toString()}`,
-      });
+      })
+      .transform((val) => new WrappedBigInt(val));
   }
 
   return { htmlType, minValue, maxValue, validator };

--- a/packages/tari-extension-query-builder/src/query-builder/template-reader.ts
+++ b/packages/tari-extension-query-builder/src/query-builder/template-reader.ts
@@ -21,6 +21,7 @@ export class TemplateReader {
     if (!fn) {
       return null;
     }
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     const args = fn.arguments || [];
     const isMethod = args[0]?.name === "self";
     const inputs = args.map((arg) => {

--- a/packages/tari-extension-query-builder/src/query-builder/wrapped-bigint.ts
+++ b/packages/tari-extension-query-builder/src/query-builder/wrapped-bigint.ts
@@ -1,0 +1,25 @@
+export class WrappedBigInt {
+  private value: bigint;
+
+  constructor(value: bigint | string | WrappedBigInt) {
+    if (value instanceof WrappedBigInt) {
+      this.value = value.value;
+    } else if (typeof value === "string") {
+      this.value = BigInt(value);
+    } else {
+      this.value = value;
+    }
+  }
+
+  toJSON(): string {
+    return this.value.toString();
+  }
+
+  toString(): string {
+    return this.value.toString();
+  }
+
+  valueOf(): bigint {
+    return this.value;
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1956,6 +1956,9 @@ packages:
   '@tari-project/tari-permissions@0.11.0':
     resolution: {integrity: sha512-tmRt7SUSLjcJe0L2kyMGIoUsa14gOPAKmzgKlCsZqafJVadquENe32jY+QY8KDTxQxbf/ZLLXZcckYlSPt0KYw==}
 
+  '@tari-project/tari-permissions@0.12.2':
+    resolution: {integrity: sha512-azXLaFtVvpLLD4evsOTM6rIh0EJS2D2Ag0310P/znOFPLN2dUhnK1wfioOQmHtqVs/AWbm+Ld3aKt5A3KT0m2g==}
+
   '@tari-project/tari-provider@0.11.0':
     resolution: {integrity: sha512-oBCposQkxMpSzN2Rul4UWGWPAt6FpNeu5u5Ic6e7hV3MZvJCYyahKg1j9PV80XkkEpQ7ZZVYE3KTi6KzRHabzQ==}
 
@@ -6817,6 +6820,8 @@ snapshots:
 
   '@tari-project/tari-permissions@0.11.0': {}
 
+  '@tari-project/tari-permissions@0.12.2': {}
+
   '@tari-project/tari-provider@0.11.0':
     dependencies:
       '@tari-project/tarijs-types': 0.11.0
@@ -6893,7 +6898,7 @@ snapshots:
 
   '@tari-project/wallet-connect-signer@0.11.0(@types/react@19.1.8)(react@19.0.0)(typescript@5.7.3)(zod@3.25.67)':
     dependencies:
-      '@tari-project/tari-permissions': 0.11.0
+      '@tari-project/tari-permissions': 0.12.2
       '@tari-project/tari-signer': 0.11.0
       '@tari-project/tarijs-builders': 0.11.0
       '@tari-project/tarijs-types': 0.11.0


### PR DESCRIPTION
Description
---

Fixes bigint serialization by introducing a wrapper type. #22

Motivation and Context
---

Flows with U32 and other numeric types could not be saved, since it yielded an error:
"Do not know how to serialize a BigInt".

That is because JSON.stringify() does not support BigInt serialization. We will introduce a wrapper type.

How Has This Been Tested?
---

Locally - 
<img width="681" height="256" alt="Screenshot 2025-07-23 at 13 45 19" src="https://github.com/user-attachments/assets/c31534a3-50c3-4496-812f-145139a8f7f0" />

Serialized:
```json
{
        "values": {
          "value": {
            "success": true,
            "data": "22"
          }
        }
}
```

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
