### PR TITLE
fix: default checkboxes to false

### DIFF
--- a/packages/tari-extension-query-builder/src/components/query-builder/nodes/generic/generic-node.tsx
+++ b/packages/tari-extension-query-builder/src/components/query-builder/nodes/generic/generic-node.tsx
@@ -13,7 +13,7 @@ import { OUTPUT_HEIGHT, ROW_HEIGHT, ROW_HEIGHT_PX, ROW_PADDING } from "../consta
 import CallInputCheckbox from "../../input/call-input-checkbox";
 import { Separator } from "@/components/ui/separator";
 import { CALL_NODE_RETURN, CALL_NODE_RETURN_TUPLE_1, CALL_NODE_RETURN_TUPLE_2 } from "../call-node.types";
-import { useCallback } from "react";
+import { useCallback, useEffect } from "react";
 import { SafeParseReturnType, z } from "zod";
 import CallInputSelect from "../../input/call-input-select";
 import { Label } from "@/components/ui/label";
@@ -56,6 +56,25 @@ function GenericNode(props: NodeProps<GenericNode>) {
   const handleOnChange = (argName: string, value: SafeParseReturnType<unknown, unknown>) => {
     updateNodeArgValue(id, argName, value);
   };
+
+  useEffect(() => {
+    if (!inputs) {
+      return;
+    }
+    // Update initial checkbox values to false (instead of leaving it undefined)
+    for (const input of inputs) {
+      const type = new TariType(input.type);
+      if (type.getInputControlType() === InputControlType.CheckBoxInput) {
+        const value = getNodeValue(input.name);
+        if (value == null) {
+          updateNodeArgValue(id, input.name, {
+            success: true,
+            data: false,
+          });
+        }
+      }
+    }
+  }, [id, inputs, getNodeValue, updateNodeArgValue]);
 
   return (
     <>


### PR DESCRIPTION
Description
---

If a new component call is dropped to the flow canvas, all its fields are `undefined` initially.
If a flow is executed, it will complain, if any fields are not filled in.

Checkboxes are undefined by default as well, but that is counterintuitive, since the default value for checkbox can be considered "false".
So we will default checkboxes to "false".

How Has This Been Tested?
---

Dropped a flow call with a checkbox, did not edit, and flow was executed successfully.

<img width="796" height="446" alt="Screenshot 2025-07-23 at 16 09 30" src="https://github.com/user-attachments/assets/c0a8f900-fdff-42db-adba-5d404656f012" />

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
